### PR TITLE
Add defp_testable macro

### DIFF
--- a/lib/ex_ex/ex_unit.ex
+++ b/lib/ex_ex/ex_unit.ex
@@ -1,0 +1,27 @@
+defmodule ExEx.ExUnit do
+  defmacro __using__(_opts) do
+    quote do
+      import ExEx.ExUnit
+    end
+  end
+
+  @doc """
+  Makes a function public when it's compiled for a test environment and private otherwise. This is
+  useful, for example, to test library functions that shouldn't be exported to client apps.
+  """
+  defmacro defp_testable(head, body \\ nil) do
+    if Mix.env == :test do
+      quote do
+        def unquote(head) do
+          unquote(body[:do])
+        end
+      end
+    else
+      quote do
+        defp unquote(head) do
+          unquote(body[:do])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Example:
```
defp_testable my_func do
  ...
end
```

will be made public when compiled for `:test` so that it's visible to test cases. For app code in dev/prod, though, the function will be private.